### PR TITLE
Create serializer for serializing scheme's as json

### DIFF
--- a/src/TypedTree.Generator.Core/Serialization/JsonSerializer.cs
+++ b/src/TypedTree.Generator.Core/Serialization/JsonSerializer.cs
@@ -1,0 +1,166 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+using TypedTree.Generator.Core.Scheme;
+
+namespace TypedTree.Generator.Core.Serialization
+{
+    /// <summary>
+    /// Class containing utilities for serialzing scheme's to json.
+    /// </summary>
+    public static class JsonSerializer
+    {
+        private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+        /// <summary>
+        /// Mode to use when serialzing json.
+        /// </summary>
+        public enum Mode
+        {
+            /// <summary>
+            /// Small non-formatted output.
+            /// </summary>
+            Normal = 0,
+
+            /// <summary>
+            /// Bigger formatted output.
+            /// </summary>
+            Pretty = 1
+        }
+
+        /// <summary>
+        /// Create a json representation of a tree-scheme.
+        /// </summary>
+        /// <param name="tree">TreeScheme to create json for</param>
+        /// <param name="mode">Mode to use when writing the json</param>
+        /// <returns>Json representation of the tree</returns>
+        public static string ToJson(this TreeDefinition tree, Mode mode)
+        {
+            // Create a Json.Net 'JObject' representation of the tree.
+            var jsonObject = CreateSchemeJsonObject(tree);
+
+            // Create a json string.
+            var formatting = GetFormattingSettings(mode);
+            return jsonObject.ToString(formatting);
+        }
+
+        /// <summary>
+        /// Create a json representation of a tree-scheme and write it as utf8 text to a stream.
+        /// </summary>
+        /// <param name="tree">TreeScheme to write json for</param>
+        /// <param name="mode">Mode to use when writing the json</param>
+        /// <param name="outputStream">Stream to write the json to</param>
+        public static void WriteJson(this TreeDefinition tree, Mode mode, Stream outputStream) =>
+            WriteJson(tree, mode, outputStream, Utf8NoBom, leaveOpen: false);
+
+        /// <summary>
+        /// Create a json representation of a tree-scheme and write it to a stream.
+        /// </summary>
+        /// <param name="tree">TreeScheme to write json for</param>
+        /// <param name="mode">Mode to use when writing the json</param>
+        /// <param name="outputStream">Stream to write the json to</param>
+        /// <param name="encoding">Encoding to use when writing text</param>
+        /// <param name="leaveOpen">Should the outputStream be left open or closed</param>
+        public static void WriteJson(
+            this TreeDefinition tree,
+            Mode mode,
+            Stream outputStream,
+            Encoding encoding,
+            bool leaveOpen)
+        {
+            // Create a Json.Net 'JObject' representation of the tree.
+            var jsonObject = CreateSchemeJsonObject(tree);
+
+            // Write json to the output stream.
+            using (var writer = new StreamWriter(outputStream, encoding, bufferSize: 1024, leaveOpen))
+            using (var jsonWriter = new JsonTextWriter(writer))
+            {
+                jsonWriter.Formatting = GetFormattingSettings(mode);
+
+                var serializer = Newtonsoft.Json.JsonSerializer.CreateDefault();
+                serializer.Serialize(jsonWriter, jsonObject);
+            }
+        }
+
+        private static JObject CreateSchemeJsonObject(TreeDefinition tree)
+        {
+            var obj = new JObject();
+            obj["rootAlias"] = tree.RootAlias.Identifier;
+            obj["aliases"] = new JArray(tree.Aliases.Select(CreateAliasJsonObject).ToArray());
+            obj["enums"] = new JArray(tree.Enums.Select(CreateEnumJsonObject).ToArray());
+            obj["nodes"] = new JArray(tree.Nodes.Select(CreateNodeJsonObject).ToArray());
+            return obj;
+        }
+
+        private static JObject CreateAliasJsonObject(AliasDefinition alias)
+        {
+            var obj = new JObject();
+            obj["identifier"] = alias.Identifier;
+            obj["values"] = new JArray(alias.Values.ToArray());
+            return obj;
+        }
+
+        private static JObject CreateEnumJsonObject(EnumDefinition @enum)
+        {
+            var obj = new JObject();
+            obj["identifier"] = @enum.Identifier;
+            obj["values"] = new JArray(@enum.Values.Select(CreateEntryJsonObject).ToArray());
+            return obj;
+
+            JObject CreateEntryJsonObject(EnumEntry entry)
+            {
+                var entryObj = new JObject();
+                entryObj["value"] = entry.Value;
+                entryObj["name"] = entry.Name;
+                return entryObj;
+            }
+        }
+
+        private static JObject CreateNodeJsonObject(NodeDefinition node)
+        {
+            var obj = new JObject();
+            obj["nodeType"] = node.Type;
+            obj["fields"] = new JArray(node.Fields.Select(CreateFieldJsonObject).ToArray());
+            return obj;
+        }
+
+        private static JObject CreateFieldJsonObject(INodeField field)
+        {
+            var obj = new JObject();
+            obj["name"] = field.Name;
+            obj["valueType"] = GetValueTypeString();
+            if (field.IsArray)
+                obj["isArray"] = true;
+            return obj;
+
+            string GetValueTypeString()
+            {
+                switch (field)
+                {
+                    case StringNodeField nf: return "string";
+                    case BooleanNodeField nf: return "boolean";
+                    case NumberNodeField nf: return "number";
+                    case AliasNodeField nf: return nf.Alias.Identifier;
+                    case EnumNodeField nf: return nf.Enum.Identifier;
+                }
+
+                throw new InvalidOperationException($"Unknown field type: '{field.GetType()}'");
+            }
+        }
+
+        private static Formatting GetFormattingSettings(Mode mode)
+        {
+            switch (mode)
+            {
+                case Mode.Pretty:
+                    return Formatting.Indented;
+                default:
+                    return Formatting.None;
+            }
+        }
+    }
+}

--- a/src/TypedTree.Generator.Core/TypedTree.Generator.Core.csproj
+++ b/src/TypedTree.Generator.Core/TypedTree.Generator.Core.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <!-- Dependencies -->
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
 
     <!-- Sourcelink -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />

--- a/src/TypedTree.Generator.Tests/SchemeSerializationTests.cs
+++ b/src/TypedTree.Generator.Tests/SchemeSerializationTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Linq;
+using Xunit;
+
+using TypedTree.Generator.Core.Scheme;
+using TypedTree.Generator.Core.Builder;
+using TypedTree.Generator.Core.Serialization;
+
+namespace TypedTree.Generator.Tests
+{
+    public sealed class SchemeSerializationTests
+    {
+        public static IEnumerable<object[]> GetTestTreeJsonPairsData()
+        {
+            foreach (var tuple in GetTestTreeJsonPairs())
+                yield return new object[] { tuple.tree, tuple.json };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestTreeJsonPairsData))]
+        public void CorrectJsonOutputIsGenerated(TreeDefinition tree, string expectedJson)
+        {
+            // Create json for the tree
+            var writtenJson = tree.ToJson(JsonSerializer.Mode.Normal);
+
+            // Strip whitespace (Easier to define test-data without having to worry about whitespace)
+            writtenJson = writtenJson.Replace(" ", string.Empty, StringComparison.Ordinal);
+            expectedJson = expectedJson.Replace(" ", string.Empty, StringComparison.Ordinal);
+            expectedJson = expectedJson.Replace("\n", string.Empty, StringComparison.Ordinal);
+
+            // Assert that written and expected json match.
+            Assert.Equal(expectedJson, writtenJson);
+        }
+
+        [Fact]
+        public void StringAndStreamMethodsProduceTheSameJson()
+        {
+            var scheme = GetTestTreeJsonPairs().First().tree;
+            using (var stream = new MemoryStream())
+            {
+                // Create json with string method
+                var stringText = scheme.ToJson(JsonSerializer.Mode.Pretty);
+                var stringBytes = Encoding.UTF8.GetBytes(stringText);
+
+                // Create json with stream method
+                scheme.WriteJson(JsonSerializer.Mode.Pretty, stream);
+                var streamBytes = stream.ToArray();
+
+                // Verify that they are equal
+                Assert.True(stringBytes.SequenceEqual(streamBytes));
+            }
+        }
+
+        private static IEnumerable<(TreeDefinition tree, string json)> GetTestTreeJsonPairs()
+        {
+            yield return
+            (
+                tree: TreeDefinitionBuilder.Create("AliasA", b =>
+                {
+                    b.PushAlias("AliasA", "NodeA");
+                    b.PushNode("NodeA");
+                }),
+                json: @"{
+                    ""rootAlias"": ""AliasA"",
+                    ""aliases"": [
+                        { ""identifier"": ""AliasA"", ""values"": [ ""NodeA"" ] }
+                    ],
+                    ""enums"": [ ],
+                    ""nodes"": [
+                        { ""nodeType"": ""NodeA"", ""fields"": [] }
+                    ]
+                }"
+            );
+
+            yield return
+            (
+                tree: TreeDefinitionBuilder.Create("Alias", b =>
+                {
+                    var alias = b.PushAlias("Alias", "NodeA", "NodeB");
+                    var @enum = b.PushEnum("Enum", ("A", 0), ("B", 1));
+                    b.PushNode("NodeA");
+                    b.PushNode("NodeB", bn =>
+                    {
+                        bn.PushBooleanField("field1");
+                        bn.PushStringField("field2");
+                        bn.PushNumberField("field3", isArray: true);
+                        bn.PushAliasField("field4", alias, isArray: true);
+                        bn.PushEnumField("field5", @enum, isArray: true);
+                    });
+                }),
+                json: @"{
+                    ""rootAlias"": ""Alias"",
+                    ""aliases"": [
+                        { ""identifier"": ""Alias"", ""values"": [ ""NodeA"", ""NodeB"" ] }
+                    ],
+                    ""enums"": [
+                        { ""identifier"": ""Enum"", ""values"": [
+                            { ""value"": 0, ""name"": ""A"" }, { ""value"": 1, ""name"": ""B"" }
+                        ]}
+                    ],
+                    ""nodes"": [
+                        {
+                            ""nodeType"": ""NodeA"",
+                            ""fields"": []
+                        },
+                        {
+                            ""nodeType"": ""NodeB"",
+                            ""fields"": [
+                                { ""name"": ""field1"", ""valueType"": ""boolean"" },
+                                { ""name"": ""field2"", ""valueType"": ""string"" },
+                                { ""name"": ""field3"", ""valueType"": ""number"", ""isArray"": true },
+                                { ""name"": ""field4"", ""valueType"": ""Alias"", ""isArray"": true },
+                                { ""name"": ""field5"", ""valueType"": ""Enum"", ""isArray"": true }
+                            ]
+                        }
+                    ]
+                }"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Matches the format as expected by the editor. 

Includes options for creating an in-memory string or writing straight to a stream and can optionally be pretty formatted. Implemented using Json.Net.