### PR TITLE
Add retry to 'dotnet build'

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -10,7 +10,7 @@ source ./ci/utils.sh
 verifyCommand dotnet
 
 info "Starting build"
-dotnet build src/TypedTree.Generator.sln
+withRetry dotnet build src/TypedTree.Generator.sln
 
 info "Finished build"
 exit 0

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -15,7 +15,7 @@ verifyCommand dotnet
 info "Starting tests"
 
 # Build the solution in Debug configuration (So that Debug.Asserts will fire)
-dotnet build --configuration Debug src/TypedTree.Generator.sln
+withRetry dotnet build --configuration Debug src/TypedTree.Generator.sln
 
 # Run test (And collect coverage using coverlet)
 dotnet test src/TypedTree.Generator.Tests/TypedTree.Generator.Tests.csproj \

--- a/ci/utils.sh
+++ b/ci/utils.sh
@@ -64,3 +64,21 @@ fileDoesNotExist ()
     fi
     return 0
 }
+
+withRetry ()
+{
+    local n=1
+    local max=3
+    local delay=5
+    while true; do "$@" && break ||
+    {
+        if [[ $n -lt $max ]]; then
+            ((n++))
+            warn "Command '$@' failed. Attempt $n/$max:"
+            sleep $delay;
+        else
+            fail "Command '$@' has failed after $n attempts."
+        fi
+    }
+    done
+}


### PR DESCRIPTION
Reason is that there are intermittent failures on Nuget restoring in the Azure pipeline