### PR TITLE
Support doc comments for nested types

### DIFF
--- a/src/TypedTree.Generator.Core/Mapping/NodeComments/XmlNodeCommentProvider.cs
+++ b/src/TypedTree.Generator.Core/Mapping/NodeComments/XmlNodeCommentProvider.cs
@@ -79,7 +79,7 @@ namespace TypedTree.Generator.Core.Mapping.NodeComments
 
             // Find the member element for given type using xpath.
             var typeDoc = this.document.SelectSingleNode(
-                $"//member[starts-with(@name, 'T:{type.FullName}')]");
+                $"//member[starts-with(@name, 'T:{GetCSharpTypeName(type)}')]");
             if (typeDoc == null)
                 return null;
 
@@ -90,6 +90,8 @@ namespace TypedTree.Generator.Core.Mapping.NodeComments
 
             // Sanitize the output by stripping starting whitespace from all lines.
             return Regex.Replace(summaryElement.InnerText, @"(^\s+)", string.Empty, RegexOptions.Multiline);
+
+            string GetCSharpTypeName(Type t) => t.FullName.Replace('+', '.');
         }
     }
 }


### PR DESCRIPTION
Problem was that the cil type names use `+` to separate nested types and c# uses `.` to seperate them. So the fix was just replacing `+` with `.` (This is safe because `+` is not a valid character for class or method identifiers). 