### PR TITLE
Remove Microsoft.Extensions.Logging dependency from Core

### DIFF
--- a/example/Example.csproj
+++ b/example/Example.csproj
@@ -24,7 +24,7 @@
     <None Update="brain.tree.json" CopyToOutputDirectory="PreserveNewest" />
 
     <!-- Tools -->
-    <DotNetCliToolReference Include="TypedTree.Generator.Cli" Version="1.1.*" />
+    <DotNetCliToolReference Include="TypedTree.Generator.Cli" Version="1.2.*" />
 
   </ItemGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Major.Minor adjust manually -->
   <PropertyGroup>
-    <VersionPrefix>1.2</VersionPrefix>
+    <VersionPrefix>2.0</VersionPrefix>
   </PropertyGroup>
 
   <!-- Automatically set suffix info based on environment args (if availble) -->

--- a/src/TypedTree.Generator.Cli/Application.cs
+++ b/src/TypedTree.Generator.Cli/Application.cs
@@ -16,7 +16,7 @@ namespace TypedTree.Generator.Cli
     /// </summary>
     public sealed class Application
     {
-        private readonly ILogger logger;
+        private readonly LoggerAdapter logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Application"/> class.
@@ -27,7 +27,7 @@ namespace TypedTree.Generator.Cli
             if (logger == null)
                 throw new ArgumentNullException(nameof(logger));
 
-            this.logger = logger;
+            this.logger = new LoggerAdapter(logger);
         }
 
         /// <summary>

--- a/src/TypedTree.Generator.Cli/LoggerAdapter.cs
+++ b/src/TypedTree.Generator.Cli/LoggerAdapter.cs
@@ -1,0 +1,48 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace TypedTree.Generator.Cli
+{
+    /// <summary>
+    /// Adapt a <see cref="Microsoft.Extensions.Logging.ILogger"/> to a <see cref="Core.ILogger"/>.
+    /// </summary>
+    public sealed class LoggerAdapter : Core.ILogger
+    {
+        private readonly Microsoft.Extensions.Logging.ILogger sink;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoggerAdapter"/> class.
+        /// </summary>
+        /// <param name="sink">Logger to output to.</param>
+        public LoggerAdapter(Microsoft.Extensions.Logging.ILogger sink)
+        {
+            this.sink = sink ?? throw new ArgumentNullException(nameof(sink));
+        }
+
+        /// <summary>
+        /// Check if a certain log-level of the underlying sink enabled.
+        /// </summary>
+        /// <param name="level">Level to check for.</param>
+        /// <returns>True if enabled otherwise False.</returns>
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel level) =>
+            this.sink.IsEnabled(level);
+
+        /// <inheritdoc/>
+        public void LogTrace(string message) => this.sink.LogTrace(message);
+
+        /// <inheritdoc/>
+        public void LogDebug(string message) => this.sink.LogDebug(message);
+
+        /// <inheritdoc/>
+        public void LogInformation(string message) => this.sink.LogInformation(message);
+
+        /// <inheritdoc/>
+        public void LogWarning(string message) => this.sink.LogWarning(message);
+
+        /// <inheritdoc/>
+        public void LogError(string message) => this.sink.LogError(message);
+
+        /// <inheritdoc/>
+        public void LogCritical(string message) => this.sink.LogCritical(message);
+    }
+}

--- a/src/TypedTree.Generator.Cli/TypeLoader.cs
+++ b/src/TypedTree.Generator.Cli/TypeLoader.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
 using McMaster.NETCore.Plugins.Loader;
-using Microsoft.Extensions.Logging;
 
 using TypedTree.Generator.Core.Utilities;
 
@@ -26,7 +25,7 @@ namespace TypedTree.Generator.Cli
         internal static ITypeCollection TryLoad(
             string assemblyPath,
             IEnumerable<string> dependencyDirectories,
-            ILogger logger = null)
+            Core.ILogger logger = null)
         {
             if (assemblyPath == null)
                 throw new ArgumentNullException(nameof(assemblyPath));
@@ -62,7 +61,7 @@ namespace TypedTree.Generator.Cli
             AssemblyLoadContext loadContext,
             string path,
             IEnumerable<string> dependencyDirectories,
-            ILogger logger = null)
+            Core.ILogger logger = null)
         {
             // Validate path.
             var validatedPath = ValidateFilePath(path, logger);
@@ -100,7 +99,7 @@ namespace TypedTree.Generator.Cli
             AssemblyLoadContext loadContext,
             AssemblyName assemblyName,
             IEnumerable<string> dependencyDirectories,
-            ILogger logger = null)
+            Core.ILogger logger = null)
         {
             // If assembly exists in any of the dependency paths then load it from there.
             var dependencyPath = dependencyDirectories.
@@ -154,7 +153,7 @@ namespace TypedTree.Generator.Cli
         private static bool IsAssemblyLoaded(AssemblyName assemblyName) =>
             AppDomain.CurrentDomain.GetAssemblies().Any(a => a.GetName().Name == assemblyName.Name);
 
-        private static AssemblyLoadContext CreateLoadContext(string assemblyPath, ILogger logger = null)
+        private static AssemblyLoadContext CreateLoadContext(string assemblyPath, Core.ILogger logger = null)
         {
             var validatedPath = ValidateFilePath(assemblyPath, logger);
             if (validatedPath == null)
@@ -183,7 +182,7 @@ namespace TypedTree.Generator.Cli
             return builder.Build();
         }
 
-        private static string ValidateFilePath(string path, ILogger logger = null)
+        private static string ValidateFilePath(string path, Core.ILogger logger = null)
         {
             // Determine full-path.
             string fullPath;

--- a/src/TypedTree.Generator.Cli/readme.md
+++ b/src/TypedTree.Generator.Cli/readme.md
@@ -6,7 +6,7 @@ Can be used to generate scheme files for the [**TypedTree-Editor**](https://bast
 
 Add a reference to the cli-tool to a `ItemGroup` section your of your csproj.
 ```xml
-<DotNetCliToolReference Include="TypedTree.Generator.Cli" Version="1.1.*" />
+<DotNetCliToolReference Include="TypedTree.Generator.Cli" Version="2.0.*" />
 ```
 
 ## Usage

--- a/src/TypedTree.Generator.Core/ILogger.cs
+++ b/src/TypedTree.Generator.Core/ILogger.cs
@@ -1,0 +1,44 @@
+namespace TypedTree.Generator.Core
+{
+    /// <summary>
+    /// Interface for a sink of diagnostic information.
+    /// </summary>
+    public interface ILogger
+    {
+        /// <summary>
+        /// Log a trace-level event.
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        void LogTrace(string message);
+
+        /// <summary>
+        /// Log a debug-level event.
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        void LogDebug(string message);
+
+        /// <summary>
+        /// Log a information-level event.
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        void LogInformation(string message);
+
+        /// <summary>
+        /// Log a warning-level event.
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        void LogWarning(string message);
+
+        /// <summary>
+        /// Log a error-level event.
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        void LogError(string message);
+
+        /// <summary>
+        /// Log a critical-level event.
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        void LogCritical(string message);
+    }
+}

--- a/src/TypedTree.Generator.Core/Mapping/AliasMapper.cs
+++ b/src/TypedTree.Generator.Core/Mapping/AliasMapper.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using Microsoft.Extensions.Logging;
 
 using TypedTree.Generator.Core.Builder;
 using TypedTree.Generator.Core.Scheme;

--- a/src/TypedTree.Generator.Core/Mapping/Context.cs
+++ b/src/TypedTree.Generator.Core/Mapping/Context.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text.RegularExpressions;
-using Microsoft.Extensions.Logging;
 
 using TypedTree.Generator.Core.Mapping.NodeComments;
 using TypedTree.Generator.Core.Utilities;

--- a/src/TypedTree.Generator.Core/Mapping/EnumMapper.cs
+++ b/src/TypedTree.Generator.Core/Mapping/EnumMapper.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using Microsoft.Extensions.Logging;
 
 using TypedTree.Generator.Core.Builder;
 using TypedTree.Generator.Core.Scheme;

--- a/src/TypedTree.Generator.Core/Mapping/NodeMapper.cs
+++ b/src/TypedTree.Generator.Core/Mapping/NodeMapper.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.Logging;
 
 using TypedTree.Generator.Core.Builder;
 using TypedTree.Generator.Core.Scheme;

--- a/src/TypedTree.Generator.Core/TypedTree.Generator.Core.csproj
+++ b/src/TypedTree.Generator.Core/TypedTree.Generator.Core.csproj
@@ -25,7 +25,6 @@
 
   <ItemGroup>
     <!-- Dependencies -->
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
 

--- a/src/TypedTree.Generator.Core/Utilities/TypeCollection.cs
+++ b/src/TypedTree.Generator.Core/Utilities/TypeCollection.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using Microsoft.Extensions.Logging;
 
 namespace TypedTree.Generator.Core.Utilities
 {

--- a/src/TypedTree.Generator.Core/readme.md
+++ b/src/TypedTree.Generator.Core/readme.md
@@ -11,11 +11,11 @@ Can be used for more complex integration into a build pipeline, for simple use-c
 There are two ways to add the nuget package:
 1. Run:
 ```bash
-dotnet add package TypedTree.Generator.Core --version 1.1.*
+dotnet add package TypedTree.Generator.Core --version 2.0.*
 ```
 2. Add the following to a `ItemGroup` section of your csproj:
 ```xml
-<PackageReference Include="TypedTree.Generator.Core" Version="1.1.*" />
+<PackageReference Include="TypedTree.Generator.Core" Version="2.0.*" />
 ```
 
 ## Usage


### PR DESCRIPTION
The dependency chain was too big for just a `ILogger` interface. This adds a custom `ILogger` interface to `TypedTree.Generator.Core` and adds an adapter in the cli application.